### PR TITLE
updating condition for Exercise useEffect() to update editedSets if user edits more than one exercise 

### DIFF
--- a/src/components/workout/Exercise.js
+++ b/src/components/workout/Exercise.js
@@ -16,7 +16,7 @@ export default function Exercise({
   const [editedSets, setEditedSets] = React.useState();
 
   useEffect(() => {
-    if (isOpen && !editedSets) {
+    if (isOpen && !_.isEqual(sets, editedSets)) {
       setEditedSets(_.clone(sets));
     }
   }, [isOpen, editedSets, sets]);


### PR DESCRIPTION
Before, if you edited an exercise you couldn't edit a second/third.. exercise because the editedSets list wasn't being updated.

Now, in the useEffect() if the model is open, and sets !== editedSets it will update the editedSets list for the user to edit.

@ayrock-dev  Let me know if there are any issues with this approach.