### PR TITLE
Update workout set

### DIFF
--- a/src/components/workout/Exercise.js
+++ b/src/components/workout/Exercise.js
@@ -20,7 +20,7 @@ export default function Exercise({
     if (isOpen && !_.isEqual(sets, editedSets)) {
       setEditedSets(_.clone(sets));
     }
-  }, [isOpen, editedSets, sets]);
+  }, [isOpen, sets]);
 
   const mutation = useUpdateSet();
 


### PR DESCRIPTION
So what I found, is that with the:

```
    if (isOpen && !_.isEqual(sets, editedSets)) {
      setEditedSets(_.clone(sets));
    }
```

Condition in the useEffect hook, everytime the editedSet was updated it was re-cloning the editedSets array from the original sets other than only cloning when a new exercise gets selected to edit. 

@ayrock-dev Need you input on this, I assume we either build a different useEffect() condition or we just remove editedSets from the dependency array which is what I did here. But I assume we need to think about if we ever want the the hook to fire if the editedSets gets updated. 