### PR TITLE
correct buildstamp

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,10 @@ module.exports = {
     );
     return config;
   },
+  /*
+   * GITHUB_SHA is an available environment variable in GitHub Actions
+   * https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+   */
   generateBuildId: async () =>
-    process.env.GIT_SHA ? process.env.GITHUB_SHA.slice(-8) : 'development',
+    process.env.GITHUB_SHA ? process.env.GITHUB_SHA.slice(-7) : 'development',
 };

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -77,7 +77,7 @@ function MainMenu({ className, navigate }) {
       <li className='flex'>
         <div className='flex flex-1 items-center p-4 space-x-2 text-slate-500'>
           <CogIcon className='w-6 h-6' />
-          <span>{getBuildId()}</span>
+          <span>Build {getBuildId()}</span>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
I noticed the build version in the sidebar is saying _development_ even in prod.

I fixed it, I had a damn typo 🤦 

I was able to test this fix locally by setting the `GITHUB_SHA` environment variable in my `.env.local` to an example commit string, the same way it is available within GitHub Actions:
![image](https://user-images.githubusercontent.com/7817695/154827622-e06e279c-2474-48ff-a1eb-9f5300c672ec.png)

Then I ran a production build with:
`npm run build`
`npm start`

And locally I can see that "in prod" the `GITHUB_SHA` is picked up now:

<img src="https://user-images.githubusercontent.com/7817695/154827654-099dfcaf-5a2f-4449-8126-dea1d419f2ed.png" style="width:350px" />

I also changed it to only show the last 7 digits, I kinda like that it matches what GitHub shows in it's UI:

![image](https://user-images.githubusercontent.com/7817695/154827702-92710dda-0c2b-4390-9af0-d843c00043d2.png)

