### PR TITLE
fix the overscroll bounce on iOS

### DIFF
--- a/src/components/page/page.js
+++ b/src/components/page/page.js
@@ -24,7 +24,7 @@ export default function Page({ children }) {
         )}
       >
         <TopBar onToggleMenu={() => toggleMenu()} />
-        <main className='flex overflow-y-auto flex-col flex-1 p-4'>
+        <main className='flex overflow-y-auto overscroll-none flex-col flex-1 p-4'>
           {user ? children : <Login />}
         </main>
       </div>


### PR DESCRIPTION
https://tailwindcss.com/docs/overscroll-behavior#header

I think `overscroll-none` is what we want but I can't test this until we deploy it :sob: I can't observe the overscroll on desktop.