### PR TITLE
Page Context

### DIFF
--- a/src/components/list-menu.js
+++ b/src/components/list-menu.js
@@ -1,0 +1,22 @@
+import clsx from 'clsx';
+
+export function ListMenu({ className, children }) {
+  return (
+    <ul className={clsx('flex flex-col divide-y', className)} role='tree'>
+      {children}
+    </ul>
+  );
+}
+
+export function ListMenuItem({ className, onClick, children }) {
+  if (onClick)
+    return (
+      <li className='flex'>
+        <button className={clsx('flex grow p-4', className)} type='button' onClick={onClick}>
+          {children}
+        </button>
+      </li>
+    );
+
+  return <li className={clsx('flex items-center p-4', className)}>{children}</li>;
+}

--- a/src/components/overlay.js
+++ b/src/components/overlay.js
@@ -38,7 +38,7 @@ export default function Overlay({ title, open, onClose, initialFocus, children }
               </button>
             </div>
           </Dialog.Title>
-          <div className='flex overflow-y-auto flex-col grow p-6'>{children}</div>
+          <div className='flex overflow-y-auto flex-col grow'>{children}</div>
         </div>
       </Dialog>
     </Transition>

--- a/src/components/page/index.js
+++ b/src/components/page/index.js
@@ -1,1 +1,1 @@
-export { default } from './page';
+export { default, PageContextProvider, usePageContext, usePageContextValues } from './page';

--- a/src/components/page/page.js
+++ b/src/components/page/page.js
@@ -31,3 +31,62 @@ export default function Page({ children }) {
     </div>
   );
 }
+
+const INITIAL_PAGE_CONTEXT = {
+  title: null,
+  onMoreAction: null,
+  withPageContext: null,
+  resetPageContext: null,
+};
+
+const PageContext = React.createContext(INITIAL_PAGE_CONTEXT);
+
+export function PageContextProvider({ children }) {
+  const [value, setValue] = React.useState(INITIAL_PAGE_CONTEXT);
+
+  const set = React.useCallback(
+    ({ title = null, onMoreAction = null } = {}) => {
+      setValue({
+        title,
+        onMoreAction,
+      });
+    },
+    [setValue]
+  );
+
+  const reset = React.useCallback(() => {
+    set({
+      title: null,
+      onMoreAction: null,
+    });
+  }, [set]);
+
+  const context = React.useMemo(
+    () => ({
+      title: value.title,
+      onMoreAction: value.onMoreAction,
+      set,
+      reset,
+    }),
+    [set, reset, value]
+  );
+
+  return <PageContext.Provider value={context}>{children}</PageContext.Provider>;
+}
+
+export const usePageContext = ({ title, onMoreAction }) => {
+  const { set, reset } = React.useContext(PageContext);
+
+  React.useEffect(() => {
+    set({ title, onMoreAction });
+
+    return () => {
+      reset();
+    };
+  }, [set, reset, title, onMoreAction]);
+};
+
+export const usePageContextValues = () => {
+  const { setPageContext, resetPageContext, ...context } = React.useContext(PageContext);
+  return context;
+};

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 
 import { getBuildId } from '../../lib/server';
 import { useUser } from '../auth';
+import { ListMenu, ListMenuItem } from '../list-menu';
 
 const links = [
   {
@@ -70,30 +71,22 @@ function SideBarButton({ Icon, className, ...props }) {
 
 function MainMenu({ className, navigate }) {
   return (
-    <ul className={clsx('flex flex-col divide-y', className)} role='tree'>
+    <ListMenu className={clsx('divide-y', className)}>
       {links.map((link) => (
-        <MainMenuItem key={link.title} navigate={navigate} {...link} />
+        <MainMenuLink key={link.title} navigate={navigate} {...link} />
       ))}
-      <li className='flex'>
-        <div className='flex flex-1 items-center p-4 space-x-2 text-slate-500'>
-          <CogIcon className='w-6 h-6' />
-          <span>Build {getBuildId()}</span>
-        </div>
-      </li>
-    </ul>
+      <ListMenuItem className='space-x-2 text-slate-500'>
+        <CogIcon className='w-6 h-6' />
+        <span>Build {getBuildId()}</span>
+      </ListMenuItem>
+    </ListMenu>
   );
 }
 
-function MainMenuItem({ navigate, title, href }) {
+function MainMenuLink({ navigate, title, href }) {
   return (
-    <li className='flex'>
-      <button
-        type='button'
-        onClick={() => navigate(href)}
-        className='flex flex-1 items-center p-4 font-medium'
-      >
-        {title}
-      </button>
-    </li>
+    <ListMenuItem onClick={() => navigate(href)} className='font-medium'>
+      {title}
+    </ListMenuItem>
   );
 }

--- a/src/components/topbar/topbar.js
+++ b/src/components/topbar/topbar.js
@@ -1,11 +1,24 @@
 import { DotsHorizontalIcon, MenuIcon } from '@heroicons/react/solid';
 import clsx from 'clsx';
 
+import { usePageContextValues } from '../page';
+
 export default function TopBar({ onToggleMenu }) {
+  const { title, onMoreAction } = usePageContextValues();
+
   return (
     <div className='flex justify-between items-center px-1 h-12 bg-slate-50 border-b'>
       <TopBarButton Icon={MenuIcon} className='shrink-0' onClick={onToggleMenu} />
-      <TopBarButton Icon={DotsHorizontalIcon} className='shrink-0' />
+      <div className='flex grow justify-center items-center'>
+        <span className='font-medium'>{title}</span>
+      </div>
+      {onMoreAction && (
+        <TopBarButton
+          Icon={DotsHorizontalIcon}
+          className='shrink-0'
+          onClick={() => onMoreAction()}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/workout/overlays/add-exercise.js
+++ b/src/components/workout/overlays/add-exercise.js
@@ -33,27 +33,25 @@ export default function AddExercise({ open, onClose }) {
     <Overlay title='Add Exercise' open={open} onClose={onClose} initialFocus={inputRef}>
       {isLoading && <LoadingIcon className='w-5 h-5' />}
       {!isLoading && (
-        <div className='flex flex-col space-y-4 h-full'>
-          <div className='flex flex-col h-full'>
-            <div className='flex flex-wrap grow-0 shrink-0 justify-between items-baseline'>
-              <Label htmlFor='name'>Exercise name</Label>
-            </div>
-            <ListboxInput
-              options={exercises}
-              field='name'
-              predicate={predicate}
-              exactPredicate={exactPredicate}
-              onSelect={onSelect}
-              onSubmit={onSubmit}
-              autoFocus
-              type='text'
-              id='name'
-              name='name'
-              autoComplete='off'
-              required
-              ref={inputRef}
-            />
+        <div className='flex flex-col p-6 space-y-4 h-full'>
+          <div className='flex flex-wrap grow-0 shrink-0 justify-between items-baseline'>
+            <Label htmlFor='name'>Exercise name</Label>
           </div>
+          <ListboxInput
+            options={exercises}
+            field='name'
+            predicate={predicate}
+            exactPredicate={exactPredicate}
+            onSelect={onSelect}
+            onSubmit={onSubmit}
+            autoFocus
+            type='text'
+            id='name'
+            name='name'
+            autoComplete='off'
+            required
+            ref={inputRef}
+          />
         </div>
       )}
     </Overlay>

--- a/src/components/workout/overlays/edit-workout.js
+++ b/src/components/workout/overlays/edit-workout.js
@@ -1,0 +1,39 @@
+import { TrashIcon } from '@heroicons/react/solid';
+import dayjs from 'dayjs';
+import React from 'react';
+
+import { useUpdateSet } from '../../../hooks/use-sets';
+import { ListMenu, ListMenuItem } from '../../list-menu';
+import LoadingIcon from '../../loading-icon';
+import Overlay from '../../overlay';
+
+export default function EditWorkout({ workout: { createdAt, updatedAt } = {}, open, onClose }) {
+  const mutation = useUpdateSet();
+  // TODO: :point_up: actually use this mutation
+
+  const createdAtMessage = `Started on ${dayjs(createdAt).format('MMM DD, YYYY h:mm a')}`;
+  const updatedAtMessage = `Last edited on ${dayjs(updatedAt).format('MMM DD, YYYY h:mm a')}`;
+
+  return (
+    <Overlay open={open} onClose={onClose}>
+      <div className='flex flex-col'>
+        {mutation.isLoading && <LoadingIcon className='w-5 h-5' />}
+        {!mutation.isLoading && (
+          <ListMenu>
+            <ListMenuItem onClick={() => undefined} className='font-medium'>
+              Rename (TODO)
+            </ListMenuItem>
+            <ListMenuItem className='text-slate-500'>{createdAtMessage}</ListMenuItem>
+            <ListMenuItem className='text-slate-500'>{updatedAtMessage}</ListMenuItem>
+            <ListMenuItem onClick={() => undefined} className='text-red-500'>
+              <div className='flex flex-1 items-center space-x-2'>
+                <TrashIcon className='w-5 h-5' />
+                <span>Delete</span>
+              </div>
+            </ListMenuItem>
+          </ListMenu>
+        )}
+      </div>
+    </Overlay>
+  );
+}

--- a/src/components/workout/pages/workout-home.js
+++ b/src/components/workout/pages/workout-home.js
@@ -7,12 +7,14 @@ import { useWorkouts } from '../../../hooks/use-workouts';
 import Button from '../../button';
 import Card from '../../card';
 import LoadingIcon from '../../loading-icon';
-import { H1, Paragraph } from '../../typography';
+import { usePageContext } from '../../page';
+import { Paragraph } from '../../typography';
 import AddWorkout from '../overlays/add-workout';
 
 export default function WorkoutsHome() {
   const router = useRouter();
   const { data: workouts, error, isLoading } = useWorkouts();
+  usePageContext({ title: 'My Workouts' });
 
   const [showWorkoutDialog, setShowWorkoutDialog] = React.useState(false);
   const openWorkoutDialog = () => setShowWorkoutDialog(true);
@@ -23,7 +25,6 @@ export default function WorkoutsHome() {
   return (
     <>
       <div className='flex flex-col flex-1 space-y-4'>
-        <H1>Workouts</H1>
         <div className='flex flex-col flex-1 space-y-2'>
           {isLoading && <LoadingIcon className='self-center w-12 h-12' />}
           {!isLoading &&

--- a/src/components/workout/pages/workout.js
+++ b/src/components/workout/pages/workout.js
@@ -4,15 +4,17 @@ import React from 'react';
 
 import { useExercises } from '../../../hooks/use-exercises';
 import { useSets } from '../../../hooks/use-sets';
-import useWorkout from '../../../hooks/use-workout';
+import { useWorkout } from '../../../hooks/use-workout';
 import Button from '../../button';
 import Card from '../../card';
 import LoadingIcon from '../../loading-icon';
+import { usePageContext } from '../../page';
 import { H1, Paragraph } from '../../typography';
 import SetsTable from '../components/sets-table';
 import AddExercise from '../overlays/add-exercise';
 import AddSet from '../overlays/add-set';
 import EditExercise from '../overlays/edit-exercise';
+import EditWorkout from '../overlays/edit-workout';
 
 export default function Workout() {
   const router = useRouter();
@@ -24,6 +26,16 @@ export default function Workout() {
 
   const [activeExerciseId, setActiveExerciseId] = React.useState(null);
   const [exercisesById, setExercisesById] = React.useState({});
+
+  // EditWorkout dialog
+  const [showEditWorkoutDialog, setShowEditWorkoutDialog] = React.useState(false);
+  const openEditWorkoutDialog = React.useCallback(
+    () => setShowEditWorkoutDialog(true),
+    [setShowEditWorkoutDialog]
+  );
+  const closeEditWorkoutDialog = () => setShowEditWorkoutDialog(false);
+
+  usePageContext({ title: 'Workout', onMoreAction: openEditWorkoutDialog });
 
   // AddSet dialog
   const [showSetsDialog, setShowSetsDialog] = React.useState(false);
@@ -127,6 +139,11 @@ export default function Workout() {
             sets={setsByExercise[activeExerciseId]}
             open={showEditExerciseDialog}
             onClose={closeEditExercise}
+          />
+          <EditWorkout
+            open={showEditWorkoutDialog}
+            onClose={closeEditWorkoutDialog}
+            workout={workout}
           />
         </>
       )}

--- a/src/hooks/use-workout.js
+++ b/src/hooks/use-workout.js
@@ -1,9 +1,26 @@
-import { useQuery } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 
-export default function useWorkout(workoutId) {
+import queryClient from '../lib/query-client';
+
+export function useWorkout(workoutId) {
   return useQuery(
     ['workout', workoutId],
     () => fetch(`/api/workout/${workoutId}`).then((res) => res.json()),
     { enabled: !!workoutId }
+  );
+}
+
+export function useUpdateWorkout() {
+  return useMutation(
+    (workout) =>
+      fetch('/api/workout', {
+        method: 'PUT',
+        body: JSON.stringify(workout),
+      }).then((res) => res.json()),
+    {
+      onSuccess: (workout) => {
+        queryClient.invalidateQueries(['workout', workout.id]);
+      },
+    }
   );
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -5,7 +5,7 @@ import { QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 
 import { UserProvider } from '../components/auth';
-import Page from '../components/page/page';
+import Page, { PageContextProvider } from '../components/page';
 import useAppLayout from '../hooks/use-app-layout';
 import queryClient from '../lib/query-client';
 
@@ -15,17 +15,19 @@ function App({ Component, pageProps }) {
   return (
     <UserProvider>
       <QueryClientProvider client={queryClient}>
-        <Head>
-          <meta name='description' content='Nexus Fitness' />
-          <link rel='icon' href='/favicon.ico' />
-          <meta name='author' content='Nexus Fitness' />
-          <meta name='theme-color' content='#B12A34' />
-          <meta name='viewport' content='width=device-width, initial-scale=1' />
-          <meta property='og:image' content='/favicon.ico' />
-        </Head>
-        <Page>
-          <Component {...pageProps} />
-        </Page>
+        <PageContextProvider>
+          <Head>
+            <meta name='description' content='Nexus Fitness' />
+            <link rel='icon' href='/favicon.ico' />
+            <meta name='author' content='Nexus Fitness' />
+            <meta name='theme-color' content='#B12A34' />
+            <meta name='viewport' content='width=device-width, initial-scale=1' />
+            <meta property='og:image' content='/favicon.ico' />
+          </Head>
+          <Page>
+            <Component {...pageProps} />
+          </Page>
+        </PageContextProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </UserProvider>


### PR DESCRIPTION
## Part I: Page Context

I added a system where a page can register a `title` and a `onMoreAction` with `usePageContext(. . . )`.

### Title

Below will register the page title Foo:
```javascript
usePageContext({ title: 'Foo' })` 
```

### The More-Action

Setting an `onMoreAction` indicates that the `. . .` button should be displayed in the `TopBar`, and the callback is called on click:
 ```javascript
 usePageContext({ title: 'Foo', onMoreAction: () => console.log('Bar') });
 ```
 
 ### Top Bar
 
 The `TopBar` component subscribes to the page context values with `usePageContextValues()` and then displays the correct elements in the header.
 
For example, a specific Workout page registers an example `onMoreAction`, so the `TopBar` displays the `. . .` button.
![image](https://user-images.githubusercontent.com/7817695/154867280-15cd6272-5376-4093-9965-edbe1ff5367a.png)

However, the My Workouts page does not register an `onMoreAction`, so the `TopBar` does not display the `. . .` button.
![image](https://user-images.githubusercontent.com/7817695/154867351-a566e83b-f97a-4692-9cf7-3d2c00dfe546.png)


### TODO
- When the `. . .` button is not displayed, the title is not cenetered. TODO: use a spacer/placeholder for the `. . .` button when it is not visible.
- Hook up the rename/delete logic in `EditWorkout` (the overlay that comes up when you click `. . .` on a Workout page. For now I focused on wiring, we can add functionality later.
- Move hooks into `/hooks` dir. Right now the `/components/auth` hooks and these page context hooks in `/components/page` should be moved to `/hooks` but moving files made a disgusting diff. TODO in a separate PR.